### PR TITLE
Add customizable callbacks OnDllLoaded and Unloaded

### DIFF
--- a/scripts/DllCallbacks.cs
+++ b/scripts/DllCallbacks.cs
@@ -1,0 +1,35 @@
+﻿namespace UnityNativeTool
+{
+    /// <summary>
+    /// A place to implement you custom callbacks.
+    /// </summary>
+    public static class DllCallbacks
+    {
+        /// <summary>
+        /// This is called whenever a dll has been loaded.
+        /// </summary>
+        /// <param name="dllName">The name without preceding underscores or file extension.</param>
+        public static void OnDllLoaded(string dllName)
+        {
+            // Debug.Log("[dll] " + dllName + " dll loaded.");
+        }
+        
+        /// <summary>
+        /// This is called whenever a dll is about to be unloaded.
+        /// </summary>
+        /// <param name="dllName">The name without preceding underscores or file extension.</param>
+        public static void OnBeforeDllUnload(string dllName)
+        {
+            // Debug.Log("[dll] " + dllName + " dll unloading...");
+        }
+        
+        /// <summary>
+        /// This is called whenever a dll has been unloaded.
+        /// </summary>
+        /// <param name="dllName">The name without preceding underscores or file extension.</param>
+        public static void OnAfterDllUnload(string dllName)
+        {
+            // Debug.Log("[dll] " + dllName + " dll unloaded.");
+        }
+    }
+}

--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -76,12 +76,14 @@ namespace UnityNativeTool.Internal
                     if (dll.handle != IntPtr.Zero)
                     {
                         LowLevelPluginManager.OnBeforeDllUnload(dll);
+                        DllCallbacks.OnBeforeDllUnload(dll.name);
 
                         bool success = SysUnloadDll(dll.handle);
                         if (!success)
                             Debug.LogWarning($"Error while unloading DLL \"{dll.name}\" at path \"{dll.path}\"");
 
                         dll.ResetAsUnloaded();
+                        DllCallbacks.OnAfterDllUnload(dll.name);
                     }
                 }
             }
@@ -424,6 +426,7 @@ namespace UnityNativeTool.Internal
                 {
                     dll.loadingError = false;
                     LowLevelPluginManager.OnDllLoaded(dll);
+                    DllCallbacks.OnDllLoaded(dll.name);
                 }
             }
 


### PR DESCRIPTION
Allows users to write their custom code in these callback functions inside the DllCallbacks.cs file.
Implemented: OnDllLoaded, OnBeforeDllUnload, OnAfterDllUnload
Currently only the name is passed as an argument, this could be extended to be the NativeDll class (which is currently internal)
