### PR TITLE
Editor GUI Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Tool created mainly to solve old problem with reloading [native plugins](https:/
 - Options are accessible via `DllManipulatorScript` editor or window.
 - Although this tool presumably works in built game, it's intended to be used in editor.
 - Get callbacks in C# when the dll load state has changed with attributes like `[NativeDllLoadedTrigger]`, see `Attributes.cs` for more information
+- Unload and load all DLLs via shortcut `Alt+D` and `Alt+Shfit+D` respectively. Editable in the Shortcut Manager for 2019.1+
 
 ## Limitations
 - Marshaling parameter attributes other than `[MarshalAs]`, `[In]` and `[Out]` are not supported.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Tool created mainly to solve old problem with reloading [native plugins](https:/
 - If something is not working, first check out available options (and read their descriptions), then [report an issue](https://github.com/mcpiroman/UnityNativeTool/issues/new).
 - Options are accessible via `DllManipulatorScript` editor or window.
 - Although this tool presumably works in built game, it's intended to be used in editor.
+- Get callbacks in C# when the dll load state has changed with attributes like `[NativeDllLoadedTrigger]`, see `Attributes.cs` for more information
 
 ## Limitations
 - Marshaling parameter attributes other than `[MarshalAs]`, `[In]` and `[Out]` are not supported.

--- a/scripts/Attributes.cs
+++ b/scripts/Attributes.cs
@@ -30,13 +30,24 @@ namespace UnityNativeTool
 
     }
 
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public class TriggerAttribute : Attribute
+    {
+        /// <summary>
+        /// Should the method always be executed on the main thread, to allow use of the Unity API.
+        /// Note: this means the method is not immediately executed but put in a queue.
+        /// For consistent behaviour, the method is put in the queue even if it is triggered from the main thread.
+        /// </summary>
+        public bool UseMainThreadQueue = false;
+    }
+    
     /// <summary>
     /// Methods with this attribute are called directly after a native DLL has been loaded.
     /// Such method must be <see langword="static"/> and either have no parameters or one parameter of type <see cref="NativeDll"/>
     /// which indicates the state of the dll being loaded. Please treat this parameter as readonly.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-    public class NativeDllLoadedTriggerAttribute : Attribute
+    public class NativeDllLoadedTriggerAttribute : TriggerAttribute
     {
 
     }
@@ -47,7 +58,7 @@ namespace UnityNativeTool
     /// which indicates the state of the dll being unloaded. Please treat this parameter as readonly.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-    public class NativeDllBeforeUnloadTriggerAttribute : Attribute
+    public class NativeDllBeforeUnloadTriggerAttribute : TriggerAttribute
     {
 
     }
@@ -58,7 +69,7 @@ namespace UnityNativeTool
     /// which indicates the state of the dll being unloaded. Please treat this parameter as readonly.
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
-    public class NativeDllAfterUnloadTriggerAttribute : Attribute
+    public class NativeDllAfterUnloadTriggerAttribute : TriggerAttribute
     {
 
     }

--- a/scripts/Attributes.cs
+++ b/scripts/Attributes.cs
@@ -30,13 +30,20 @@ namespace UnityNativeTool
 
     }
 
+    /// <summary>
+    /// Such a method must be static and have one of the following signatures:
+    /// <code>
+    /// public static void Func()
+    /// public static void Func(NativeDll dll)
+    /// public static void Func(NativeDll dll, int mainThreadId)
+    /// </code>
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
     public class TriggerAttribute : Attribute
     {
         /// <summary>
         /// Should the method always be executed on the main thread, to allow use of the Unity API.
-        /// Note: this means the method is not immediately executed but put in a queue.
-        /// For consistent behaviour, the method is put in the queue even if it is triggered from the main thread.
+        /// Note: this means the method is not immediately executed but put in a queue, if it is not triggered from the main thread.
         /// </summary>
         public bool UseMainThreadQueue = false;
     }
@@ -45,6 +52,7 @@ namespace UnityNativeTool
     /// Methods with this attribute are called directly after a native DLL has been loaded.
     /// Such method must be <see langword="static"/> and either have no parameters or one parameter of type <see cref="NativeDll"/>
     /// which indicates the state of the dll being loaded. Please treat this parameter as readonly.
+    /// <br/><inheritdoc cref="TriggerAttribute"/>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class NativeDllLoadedTriggerAttribute : TriggerAttribute
@@ -56,6 +64,7 @@ namespace UnityNativeTool
     /// Methods with this attribute are called directly before a native DLL is going to be unloaded.
     /// Such method must be <see langword="static"/> and either have no parameters or one parameter of type <see cref="NativeDll"/>
     /// which indicates the state of the dll being unloaded. Please treat this parameter as readonly.
+    /// <br/><inheritdoc cref="TriggerAttribute"/>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class NativeDllBeforeUnloadTriggerAttribute : TriggerAttribute
@@ -67,6 +76,7 @@ namespace UnityNativeTool
     /// Methods with this attribute are called directly after a native DLL has been unloaded.
     /// Such method must be <see langword="static"/> and either have no parameters or one parameter of type <see cref="NativeDll"/>
     /// which indicates the state of the dll being unloaded. Please treat this parameter as readonly.
+    /// <br/><inheritdoc cref="TriggerAttribute"/>
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class NativeDllAfterUnloadTriggerAttribute : TriggerAttribute

--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -692,6 +692,33 @@ namespace UnityNativeTool.Internal
         public bool mockAllNativeFunctions;
         public bool onlyInEditor;
         public bool enableInEditMode;
+
+        public DllManipulatorOptions CloneTo(DllManipulatorOptions other)
+        {
+            other.dllPathPattern = dllPathPattern;
+            other.assemblyNames = (string[]) assemblyNames.Clone();
+            other.loadingMode = loadingMode;
+            other.posixDlopenFlags = posixDlopenFlags;
+            other.threadSafe = threadSafe;
+            other.enableCrashLogs = enableCrashLogs;
+            other.crashLogsDir = crashLogsDir;
+            other.crashLogsStackTrace = crashLogsStackTrace;
+            other.mockAllNativeFunctions = mockAllNativeFunctions;
+            other.onlyInEditor = onlyInEditor;
+            other.enableInEditMode = enableInEditMode;
+            
+            return other;
+        }
+
+        public bool Equals(DllManipulatorOptions other)
+        {
+            return other.dllPathPattern == dllPathPattern && other.assemblyNames.SequenceEqual(assemblyNames) &&
+                   other.loadingMode == loadingMode && other.posixDlopenFlags == posixDlopenFlags &&
+                   other.threadSafe == threadSafe && other.enableCrashLogs == enableCrashLogs &&
+                   other.crashLogsDir == crashLogsDir && other.crashLogsStackTrace == crashLogsStackTrace &&
+                   other.mockAllNativeFunctions == mockAllNativeFunctions && other.onlyInEditor == onlyInEditor &&
+                   other.enableInEditMode == enableInEditMode;
+        }
     }
 
     public enum DllLoadingMode

--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -100,6 +100,20 @@ namespace UnityNativeTool.Internal
                 LoadAll();
         }
 
+        /// <summary>
+        /// Will unload/forget all dll's and reset the state 
+        /// </summary>
+        public static void Reset()
+        {
+            UnloadAll();
+            ForgetAllDlls();
+            ClearCrashLogs();
+            
+            _customLoadedTriggers?.Clear();
+            _customAfterUnloadTriggers?.Clear();
+            _customBeforeUnloadTriggers?.Clear();
+        }
+        
         private static void RegisterTriggerMethod(MethodInfo method, ref List<MethodInfo> triggersList)
         {
             var parameters = method.GetParameters();

--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -81,17 +81,16 @@ namespace UnityNativeTool.Internal
                             if (Options.mockAllNativeFunctions || method.IsDefined(typeof(MockNativeDeclarationAttribute)) || method.DeclaringType.IsDefined(typeof(MockNativeDeclarationsAttribute)))
                                 MockNativeFunction(method);
                         }
-                        else if(method.IsDefined(typeof(NativeDllLoadedTriggerAttribute)))
+                        else
                         {
-                            RegisterTriggerMethod(method, ref _customLoadedTriggers);
-                        }
-                        else if (method.IsDefined(typeof(NativeDllBeforeUnloadTriggerAttribute)))
-                        {
-                            RegisterTriggerMethod(method, ref _customBeforeUnloadTriggers);
-                        }
-                        else if (method.IsDefined(typeof(NativeDllAfterUnloadTriggerAttribute)))
-                        {
-                            RegisterTriggerMethod(method, ref _customAfterUnloadTriggers);
+                            if (method.IsDefined(typeof(NativeDllLoadedTriggerAttribute)))
+                                RegisterTriggerMethod(method, ref _customLoadedTriggers);
+
+                            if (method.IsDefined(typeof(NativeDllBeforeUnloadTriggerAttribute)))
+                                RegisterTriggerMethod(method, ref _customBeforeUnloadTriggers);
+
+                            if (method.IsDefined(typeof(NativeDllAfterUnloadTriggerAttribute)))
+                                RegisterTriggerMethod(method, ref _customAfterUnloadTriggers);
                         }
                     }
                 }

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -60,6 +60,7 @@ namespace UnityNativeTool
             if(EditorApplication.isPlaying || Options.enableInEditMode)
                 Initialize();
             
+            // Ensure update is called every frame in edit mode, ExecuteInEditMode only calls Update when the scene changes
             if(!EditorApplication.isPlaying && Options.enableInEditMode)
                 EditorApplication.update += Update;
 

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Reflection;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
-using System.Linq;
 using UnityEngine;
 using UnityNativeTool.Internal;
 #if UNITY_EDITOR
@@ -38,6 +38,8 @@ namespace UnityNativeTool
             onlyInEditor = true,
             enableInEditMode = false
         };
+        
+        public static ConcurrentQueue<Action> MainThreadTriggerQueue = new ConcurrentQueue<Action>();
 
         private void OnEnable()
         {
@@ -93,7 +95,17 @@ namespace UnityNativeTool
         /// </summary>
         private void Update()
         {
-            DllManipulator.InvokeMainThreadQueue();
+            InvokeMainThreadQueue();
+        }
+
+        /// <summary>
+        /// Executes queued methods.
+        /// Should be called from the main thread in Update.
+        /// </summary>
+        public static void InvokeMainThreadQueue()
+        {
+            while (MainThreadTriggerQueue.TryDequeue(out var action))
+                action();
         }
 
 #if UNITY_EDITOR

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -92,9 +92,7 @@ namespace UnityNativeTool
                 //On Preloaded mode this leads to NullReferenceException, but on Lazy mode the DLL and function would be just reloaded so we would up with loaded DLL after game exit.
                 //Thankfully thread safety with Lazy mode is not implemented yet.
 
-                DllManipulator.UnloadAll();
-                DllManipulator.ForgetAllDlls();
-                DllManipulator.ClearCrashLogs();
+                DllManipulator.Reset();
                 _singletonInstance = null;
             }
         }

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -46,7 +46,7 @@ namespace UnityNativeTool
             {
                 if (EditorApplication.isPlaying)
                     Destroy(gameObject);
-                else
+                else if(_singletonInstance != this)
                     enabled = false; //Don't destroy as the user may be editing a Prefab
                 return;
             }

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -57,6 +57,10 @@ namespace UnityNativeTool
 
             if(EditorApplication.isPlaying || Options.enableInEditMode)
                 Initialize();
+            
+            if(!EditorApplication.isPlaying && Options.enableInEditMode)
+                EditorApplication.update += Update;
+
 #else
             if (Options.onlyInEditor) 
                 return;
@@ -82,6 +86,20 @@ namespace UnityNativeTool
 
             initTimer.Stop();
             InitializationTime = initTimer.Elapsed;
+        }
+        
+        /// <summary>
+        /// Note: also called in edit mode if Options.enableInEditMode is set.
+        /// </summary>
+        private void Update()
+        {
+            DllManipulator.InvokeMainThreadQueue();
+        }
+
+        private void OnDisable()
+        {
+            if(!EditorApplication.isPlaying && Options.enableInEditMode)
+                EditorApplication.update -= Update;
         }
 
         private void OnDestroy()

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -96,11 +96,13 @@ namespace UnityNativeTool
             DllManipulator.InvokeMainThreadQueue();
         }
 
+#if UNITY_EDITOR
         private void OnDisable()
         {
             if(!EditorApplication.isPlaying && Options.enableInEditMode)
                 EditorApplication.update -= Update;
         }
+#endif
 
         private void OnDestroy()
         {

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -110,7 +110,8 @@ namespace UnityNativeTool
                 //On Preloaded mode this leads to NullReferenceException, but on Lazy mode the DLL and function would be just reloaded so we would up with loaded DLL after game exit.
                 //Thankfully thread safety with Lazy mode is not implemented yet.
 
-                DllManipulator.Reset();
+                if (DllManipulator.Options != null) // Check that we have initialized
+                    DllManipulator.Reset();
                 _singletonInstance = null;
             }
         }

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -367,7 +367,7 @@ namespace UnityNativeTool.Internal
         [NativeDllAfterUnloadTrigger(UseMainThreadQueue = true)]
         public static void RepaintAll()
         {
-            RepaintAllEditors.Invoke();
+            RepaintAllEditors?.Invoke();
         }
     }
 }

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -61,11 +61,14 @@ namespace UnityNativeTool.Internal
         private bool _showTargetAssemblies = true;
         private string[] _allKnownAssemblies = null;
         private DateTime _lastKnownAssembliesRefreshTime;
-
+        
+        public static event Action RepaintAllEditors = delegate {};
+        
         public DllManipulatorEditor()
         {
             EditorApplication.pauseStateChanged += _ => Repaint();
             EditorApplication.playModeStateChanged += _ => Repaint();
+            RepaintAllEditors += Repaint;
         }
 
         public override void OnInspectorGUI()
@@ -346,10 +349,7 @@ namespace UnityNativeTool.Internal
         [NativeDllAfterUnloadTrigger]
         public static void RepaintAll()
         {
-            var editors = Resources.FindObjectsOfTypeAll<DllManipulatorEditor>();
-            if(editors == null) return;
-            foreach (var editor in editors)
-                editor.Repaint();
+            RepaintAllEditors.Invoke();
         }
     }
 }

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -322,6 +322,8 @@ namespace UnityNativeTool.Internal
         public static void LoadAllShortcut()
         {
             DllManipulator.LoadAll();
+            RepaintAll();
+            DllManipulatorWindowEditor.RepaintAll();
         }
 
         #if UNITY_2019_1_OR_NEWER
@@ -332,6 +334,16 @@ namespace UnityNativeTool.Internal
         public static void UnloadAll()
         {
             DllManipulator.UnloadAll();
+            RepaintAll();
+            DllManipulatorWindowEditor.RepaintAll();
+        }
+
+        public static void RepaintAll()
+        {
+            var editors = Resources.FindObjectsOfTypeAll<DllManipulatorEditor>();
+            if(editors == null) return;
+            foreach (var editor in editors)
+                editor.Repaint();
         }
     }
 }

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -8,8 +8,6 @@ using UnityEditor.ShortcutManagement;
 #endif
 using System.IO;
 using System;
-using UnityEditor.SceneManagement;
-using UnityEngine.SceneManagement;
 
 namespace UnityNativeTool.Internal
 {
@@ -148,7 +146,6 @@ namespace UnityNativeTool.Internal
             if (GUI.changed)
             {
                 EditorUtility.SetDirty(target);
-                EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
             }
         }
 

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -63,6 +63,11 @@ namespace UnityNativeTool.Internal
         private bool _showTargetAssemblies = true;
         private string[] _allKnownAssemblies = null;
         private DateTime _lastKnownAssembliesRefreshTime;
+
+        /// <summary>
+        /// To check if the options have change in order to set the object as dirty
+        /// </summary>
+        private DllManipulatorOptions _prevOptions = new DllManipulatorOptions();
         
         public static event Action RepaintAllEditors = delegate {};
         
@@ -71,6 +76,11 @@ namespace UnityNativeTool.Internal
             EditorApplication.pauseStateChanged += _ => Repaint();
             EditorApplication.playModeStateChanged += _ => Repaint();
             RepaintAllEditors += Repaint;
+        }
+        
+        private void Awake()
+        {
+            ((DllManipulatorScript)target).Options.CloneTo(_prevOptions);
         }
 
         public override void OnInspectorGUI()
@@ -147,9 +157,14 @@ namespace UnityNativeTool.Internal
                 EditorGUILayout.LabelField($"Initialized in: {(int)time.TotalSeconds}.{time.Milliseconds.ToString("D3")}s");
             }
 
+            // Set the target as dirty so changes can be saved, if there are changes
             if (GUI.changed)
             {
-                EditorUtility.SetDirty(target);
+                if (!t.Options.Equals(_prevOptions))
+                {
+                    t.Options.CloneTo(_prevOptions);
+                    EditorUtility.SetDirty(target);
+                }
             }
         }
 

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -65,7 +65,7 @@ namespace UnityNativeTool.Internal
         private DateTime _lastKnownAssembliesRefreshTime;
 
         /// <summary>
-        /// To check if the options have change in order to set the object as dirty
+        /// Used to check if the options have changed, in order to set the object as dirty so changes are saved
         /// </summary>
         private DllManipulatorOptions _prevOptions = new DllManipulatorOptions();
         
@@ -80,6 +80,7 @@ namespace UnityNativeTool.Internal
         
         private void Awake()
         {
+            // Immediately copy the Options to the previous so we don't need to check for null later
             ((DllManipulatorScript)target).Options.CloneTo(_prevOptions);
         }
 
@@ -162,6 +163,8 @@ namespace UnityNativeTool.Internal
             {
                 if (!t.Options.Equals(_prevOptions))
                 {
+                    // If the options have changed then update the _prevOptions and notify there are changes to be saved
+                    // CloneTo is used to ensure a deep copy is made
                     t.Options.CloneTo(_prevOptions);
                     EditorUtility.SetDirty(target);
                 }

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -117,9 +117,9 @@ namespace UnityNativeTool.Internal
 
 
                     bool unloadAll;
-                    if(EditorApplication.isPlaying && t.Options.threadSafe)
+                    if((EditorApplication.isPlaying || t.Options.enableInEditMode) && t.Options.threadSafe)
                         unloadAll = GUILayout.Button(UNLOAD_ALL_DLLS_WITH_THREAD_SAFETY_GUI_CONTENT);
-                    else if (EditorApplication.isPlaying && !EditorApplication.isPaused && t.Options.loadingMode == DllLoadingMode.Preload)
+                    else if ((EditorApplication.isPlaying && !EditorApplication.isPaused || t.Options.enableInEditMode) && t.Options.loadingMode == DllLoadingMode.Preload)
                         unloadAll = GUILayout.Button(UNLOAD_ALL_DLLS_IN_PLAY_PRELOADED_GUI_CONTENT);
                     else
                         unloadAll = GUILayout.Button("Unload all DLLs");
@@ -130,7 +130,7 @@ namespace UnityNativeTool.Internal
 
                 DrawUsedDlls(usedDlls);
             }
-            else if(EditorApplication.isPlaying)
+            else if(EditorApplication.isPlaying || t.Options.enableInEditMode)
             {
                 GUILayout.BeginHorizontal();
                 GUILayout.FlexibleSpace();
@@ -139,7 +139,7 @@ namespace UnityNativeTool.Internal
                 GUILayout.EndHorizontal();
             }
 
-            if(EditorApplication.isPlaying && t.InitializationTime != null)
+            if((EditorApplication.isPlaying || t.Options.enableInEditMode) && t.InitializationTime != null)
             {
                 EditorGUILayout.Space();
                 EditorGUILayout.Space();

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -330,8 +330,6 @@ namespace UnityNativeTool.Internal
         public static void LoadAllShortcut()
         {
             DllManipulator.LoadAll();
-            RepaintAll();
-            DllManipulatorWindowEditor.RepaintAll();
         }
 
         #if UNITY_2019_1_OR_NEWER
@@ -342,10 +340,10 @@ namespace UnityNativeTool.Internal
         public static void UnloadAll()
         {
             DllManipulator.UnloadAll();
-            RepaintAll();
-            DllManipulatorWindowEditor.RepaintAll();
         }
 
+        [NativeDllLoadedTrigger]
+        [NativeDllAfterUnloadTrigger]
         public static void RepaintAll()
         {
             var editors = Resources.FindObjectsOfTypeAll<DllManipulatorEditor>();

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -348,8 +348,8 @@ namespace UnityNativeTool.Internal
             DllManipulator.UnloadAll();
         }
 
-        [NativeDllLoadedTrigger]
-        [NativeDllAfterUnloadTrigger]
+        [NativeDllLoadedTrigger(UseMainThreadQueue = true)]
+        [NativeDllAfterUnloadTrigger(UseMainThreadQueue = true)]
         public static void RepaintAll()
         {
             RepaintAllEditors.Invoke();

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -8,6 +8,8 @@ using UnityEditor.ShortcutManagement;
 #endif
 using System.IO;
 using System;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
 
 namespace UnityNativeTool.Internal
 {
@@ -138,6 +140,12 @@ namespace UnityNativeTool.Internal
                 EditorGUILayout.Space();
                 var time = t.InitializationTime.Value;
                 EditorGUILayout.LabelField($"Initialized in: {(int)time.TotalSeconds}.{time.Milliseconds.ToString("D3")}s");
+            }
+
+            if (GUI.changed)
+            {
+                EditorUtility.SetDirty(target);
+                EditorSceneManager.MarkSceneDirty(SceneManager.GetActiveScene());
             }
         }
 

--- a/scripts/Editor/DllManipulatorWindowEditor.cs
+++ b/scripts/Editor/DllManipulatorWindowEditor.cs
@@ -13,13 +13,7 @@ namespace UnityNativeTool.Internal
         {
             window = GetWindow<DllManipulatorWindowEditor>();
             window.Show();
-        }
-
-        [NativeDllLoadedTrigger]
-        [NativeDllAfterUnloadTrigger]
-        public static void RepaintAll()
-        {
-            if(window) window.Repaint();
+            DllManipulatorEditor.RepaintAllEditors += window.Repaint;
         }
 
         void OnGUI()

--- a/scripts/Editor/DllManipulatorWindowEditor.cs
+++ b/scripts/Editor/DllManipulatorWindowEditor.cs
@@ -6,11 +6,18 @@ namespace UnityNativeTool.Internal
 {
     public class DllManipulatorWindowEditor : EditorWindow
     {
+        private static EditorWindow window;
+
         [MenuItem("Window/Dll manipulator")]
         static void Init()
         {
-            var window = GetWindow<DllManipulatorWindowEditor>();
+            window = GetWindow<DllManipulatorWindowEditor>();
             window.Show();
+        }
+
+        public static void RepaintAll()
+        {
+            if(window) window.Repaint();
         }
 
         void OnGUI()

--- a/scripts/Editor/DllManipulatorWindowEditor.cs
+++ b/scripts/Editor/DllManipulatorWindowEditor.cs
@@ -15,6 +15,8 @@ namespace UnityNativeTool.Internal
             window.Show();
         }
 
+        [NativeDllLoadedTrigger]
+        [NativeDllAfterUnloadTrigger]
         public static void RepaintAll()
         {
             if(window) window.Repaint();


### PR DESCRIPTION
1. Editors (component/window) are repainted when dll's are un/loaded using the new attributes
   - Involves running the triggers on the main thread in a queue 39c4fce825d7f1c4572d183ec8666593d3840f13
1. Editor variable changes are detected and saved properly
   - Involves creating a clone of the options and comparing changes when the GUI has changed 5bda99031c315006d66ea14aa8c7c949c7dabd6e

Note: The attributes `[NativeDllLoadedTrigger]` etc are not searched for in the source code of this tool itself. So by creating an `.asmdef` in #14 these attributes may not work, do you maybe know of an easy fix for this @mcpiroman?.

