### PR TITLE
Bug fix, customLoadedTriggers with preloaded mode

### DIFF
--- a/scripts/Attributes.cs
+++ b/scripts/Attributes.cs
@@ -31,9 +31,11 @@ namespace UnityNativeTool
     }
 
     /// <summary>
-    /// Methods with this attribute are called directly after a native DLL has been loaded.
+    /// Methods with this attribute are called directly after a native DLL has been loaded. Native functions can be used within such a method.
+    /// This is called after <c>UnityPluginLoad</c>.<br/>
     /// Such method must be <see langword="static"/> and either have no parameters or one parameter of type <see cref="NativeDll"/>
-    /// which indicates the state of the dll being loaded. Please treat this parameter as readonly.
+    /// which indicates the state of the dll being loaded. Please treat this parameter as readonly.<br/>
+    /// Preloaded: only called once all native methods have been loaded. 
     /// </summary>
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
     public class NativeDllLoadedTriggerAttribute : Attribute

--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -133,6 +133,8 @@ namespace UnityNativeTool.Internal
                             LoadTargetFunction(nativeFunction, false);
                         }
                         
+                        // Notify that the dll and its functions have been loaded in preload mode
+                        // This here allows use of native functions in the triggers
                         if(Options.loadingMode == DllLoadingMode.Preload)
                             InvokeCustomTriggers(_customLoadedTriggers, dll);
                     }
@@ -485,6 +487,9 @@ namespace UnityNativeTool.Internal
                 {
                     dll.loadingError = false;
                     LowLevelPluginManager.OnDllLoaded(dll);
+                    
+                    // Call the custom triggers once UnityPluginLoad has been called
+                    // For Lazy mode call the triggers immediately, preload waits until all functions are loaded (in LoadAll)
                     if(Options.loadingMode == DllLoadingMode.Lazy)
                         InvokeCustomTriggers(_customLoadedTriggers, dll);
                 }

--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -132,6 +132,9 @@ namespace UnityNativeTool.Internal
                         {
                             LoadTargetFunction(nativeFunction, false);
                         }
+                        
+                        if(Options.loadingMode == DllLoadingMode.Preload)
+                            InvokeCustomTriggers(_customLoadedTriggers, dll);
                     }
                 }
             }
@@ -481,8 +484,9 @@ namespace UnityNativeTool.Internal
                 else
                 {
                     dll.loadingError = false;
-                    InvokeCustomTriggers(_customLoadedTriggers, dll);
                     LowLevelPluginManager.OnDllLoaded(dll);
+                    if(Options.loadingMode == DllLoadingMode.Lazy)
+                        InvokeCustomTriggers(_customLoadedTriggers, dll);
                 }
             }
 


### PR DESCRIPTION
1. The loaded trigger is now called after all mocked methods have been loaded for preloaded mode. This allows using a native method inside the callback, such as a initialize function. 

2. Swapped ordering so `UnityPluginLoad()` (from `LowLevelPluginManager.OnDllLoaded(dll)`) is called before the trigger. This is unrelated to the bug but makes more sense.
