### PR TITLE
Edit options when initialized, Fix cleanup when recompiling

### DIFF
--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -30,7 +30,7 @@ namespace UnityNativeTool.Internal
         public static readonly string[] IGNORED_ASSEMBLY_PREFIXES = { "UnityEngine.", "UnityEditor.", "Unity.", "com.unity.", "Mono." , "nunit."};
 
 
-        public static DllManipulatorOptions Options { get; set; }
+        public static DllManipulatorOptions Options { get; private set; }
         private static int _unityMainThreadId;
         private static string _assetsPath;
         private static readonly LinkedList<object> _antiGcRefHolder = new LinkedList<object>();

--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -53,8 +53,11 @@ namespace UnityNativeTool.Internal
         /// If <see cref="DllLoadingMode.Preload"/> option is specified, loads all DLLs specified by these functions.
         /// Options have to be configured before calling this method.
         /// </summary>
-        internal static void Initialize(int unityMainThreadId, string assetsPath)
+        internal static void Initialize(DllManipulatorOptions options, int unityMainThreadId, string assetsPath)
         {
+            // Make a deep copy of the options so we can edit them in DllManipulatorScript independently
+            Options = new DllManipulatorOptions();
+            options.CloneTo(Options);
             _unityMainThreadId = unityMainThreadId;
             _assetsPath = assetsPath;
 
@@ -123,6 +126,8 @@ namespace UnityNativeTool.Internal
             _customLoadedTriggers?.Clear();
             _customAfterUnloadTriggers?.Clear();
             _customBeforeUnloadTriggers?.Clear();
+
+            Options = null;
         }
 
         private static void RegisterTriggerMethod(MethodInfo method, ref List<Tuple<MethodInfo, bool>> triggersList, TriggerAttribute attribute)

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -160,7 +160,7 @@ namespace UnityNativeTool
                 Reset();
         }
 
-        public void Reset()
+        private void Reset()
         {
             //Note on threading: Because we don't wait for other threads to finish, we might be stealing function delegates from under their nose if Unity doesn't happen to close them yet.
             //On Preloaded mode this leads to NullReferenceException, but on Lazy mode the DLL and function would be just reloaded so we would up with loaded DLL after game exit.

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -84,11 +84,28 @@ namespace UnityNativeTool
         {
             var initTimer = System.Diagnostics.Stopwatch.StartNew();
 
-            DllManipulator.Options = Options;
-            DllManipulator.Initialize(Thread.CurrentThread.ManagedThreadId, Application.dataPath);
+            DllManipulator.Initialize(Options, Thread.CurrentThread.ManagedThreadId, Application.dataPath);
 
             initTimer.Stop();
             InitializationTime = initTimer.Elapsed;
+        }
+
+        /// <summary>
+        /// Will reset the DllManipulator and Initialize it again.
+        /// Note: Unloads all Dlls, may be a dangerous operation if using preloaded
+        /// </summary>
+        public void Reinitialize()
+        {
+            if(_singletonInstance != this)
+                return;
+            
+            if (DllManipulator.Options != null)
+                DllManipulator.Reset();
+            
+#if UNITY_EDITOR
+            if(EditorApplication.isPlaying || Options.enableInEditMode)
+#endif
+                Initialize();
         }
         
         /// <summary>
@@ -112,7 +129,7 @@ namespace UnityNativeTool
 #if UNITY_EDITOR
         private void OnDisable()
         {
-            if(!EditorApplication.isPlaying && Options.enableInEditMode)
+            if(_singletonInstance == this && !EditorApplication.isPlaying && Options.enableInEditMode)
                 EditorApplication.update -= Update;
         }
 #endif

--- a/scripts/DllManipulatorScript.cs
+++ b/scripts/DllManipulatorScript.cs
@@ -83,7 +83,7 @@ namespace UnityNativeTool
 #endif
         }
         
-        private void Initialize()
+        public void Initialize()
         {
             var initTimer = System.Diagnostics.Stopwatch.StartNew();
 
@@ -99,11 +99,7 @@ namespace UnityNativeTool
         /// </summary>
         public void Reinitialize()
         {
-            if(_singletonInstance != this)
-                return;
-            
-            if (DllManipulator.Options != null)
-                DllManipulator.Reset();
+            DllManipulator.Reset();
             
 #if UNITY_EDITOR
             if(EditorApplication.isPlaying || Options.enableInEditMode)
@@ -152,7 +148,7 @@ namespace UnityNativeTool
                 if (_isRecompiling)
                 {
                     _isRecompiling = false;
-                    OnDestroy();
+                    Reset();
                 }
             }
         }
@@ -161,15 +157,18 @@ namespace UnityNativeTool
         private void OnDestroy()
         {
             if (_singletonInstance == this)
-            {
-                //Note on threading: Because we don't wait for other threads to finish, we might be stealing function delegates from under their nose if Unity doesn't happen to close them yet.
-                //On Preloaded mode this leads to NullReferenceException, but on Lazy mode the DLL and function would be just reloaded so we would up with loaded DLL after game exit.
-                //Thankfully thread safety with Lazy mode is not implemented yet.
+                Reset();
+        }
 
-                if (DllManipulator.Options != null) // Check that we have initialized
-                    DllManipulator.Reset();
-                _singletonInstance = null;
-            }
+        public void Reset()
+        {
+            //Note on threading: Because we don't wait for other threads to finish, we might be stealing function delegates from under their nose if Unity doesn't happen to close them yet.
+            //On Preloaded mode this leads to NullReferenceException, but on Lazy mode the DLL and function would be just reloaded so we would up with loaded DLL after game exit.
+            //Thankfully thread safety with Lazy mode is not implemented yet.
+
+            if (DllManipulator.Options != null) // Check that we have initialized
+                DllManipulator.Reset();
+            _singletonInstance = null;
         }
     }
 }

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -15,7 +15,7 @@ namespace UnityNativeTool.Internal
     public class DllManipulatorEditor : Editor
     {
         private static readonly string INFO_BOX_GUI_CONTENT = 
-            "Mocks native functions to allow manually un/loading native DLLs. DLLs are always unloaded at OnDestroy. Changes below are always applied at OnEnable.";
+            "Mocks native functions to allow manually un/loading native DLLs. DLLs are always unloaded at OnDestroy. Configuration changes below are always applied at OnEnable.";
         private static readonly GUIContent TARGET_ALL_NATIVE_FUNCTIONS_GUI_CONTENT = new GUIContent("All native functions",
             "If true, all found native functions will be mocked.\n\n" +
             $"If false, you have to select them by using [{nameof(MockNativeDeclarationsAttribute)}] or [{nameof(MockNativeDeclarationAttribute)}].");

--- a/scripts/Editor/DllManipulatorEditor.cs
+++ b/scripts/Editor/DllManipulatorEditor.cs
@@ -142,14 +142,16 @@ namespace UnityNativeTool.Internal
                         t.Reinitialize();
                 }
                 else if(GUILayout.Button(REINITIALIZE_WITH_CHANGES_LAZY_GUI_CONTENT))
+                {
                     t.Reinitialize();
+                }
             }
             
             // When enabling enableInEditMode for the first time, allow immediately initializing without waiting for OnEnable
             if(DllManipulator.Options == null && t.Options.enableInEditMode && !EditorApplication.isPlaying && 
                GUILayout.Button(INITIALIZE_ENABLED_EDIT_MODE_GUI_CONTENT))
             {
-                t.Reinitialize();
+                t.Initialize();
             }
         }
 
@@ -264,9 +266,6 @@ namespace UnityNativeTool.Internal
 
         private void DrawOptions(DllManipulatorOptions options)
         {
-            var guiEnabledStack = new Stack<bool>();
-            guiEnabledStack.Push(GUI.enabled);
-     
             options.onlyInEditor = EditorGUILayout.Toggle(ONLY_IN_EDITOR, options.onlyInEditor);
             options.enableInEditMode = EditorGUILayout.Toggle(ENABLE_IN_EDIT_MODE, options.enableInEditMode);
 
@@ -331,14 +330,14 @@ namespace UnityNativeTool.Internal
             options.posixDlopenFlags = (PosixDlopenFlags)EditorGUILayout.EnumPopup(POSIX_DLOPEN_FLAGS_GUI_CONTENT, options.posixDlopenFlags);
 #endif
 
-            guiEnabledStack.Push(GUI.enabled);
+            var guiEnabled = GUI.enabled;
             if (options.loadingMode != DllLoadingMode.Preload)
             {
                 options.threadSafe = false;
                 GUI.enabled = false;
             }
             options.threadSafe = EditorGUILayout.Toggle(THREAD_SAFE_GUI_CONTENT, options.threadSafe);
-            GUI.enabled = guiEnabledStack.Pop();
+            GUI.enabled = guiEnabled;
 
             options.enableCrashLogs = EditorGUILayout.Toggle(CRASH_LOGS_GUI_CONTENT, options.enableCrashLogs);
 
@@ -353,8 +352,6 @@ namespace UnityNativeTool.Internal
 
                 EditorGUI.indentLevel = prevIndent;
             }
-
-            GUI.enabled = guiEnabledStack.Pop();
         }
 
         /// <summary>


### PR DESCRIPTION
1. Allows editing options when initialized, this is done by having a separate copy of the Options in the script as in the manipulator. Changes are applied when entering play mode or can be applied immediately. This also avoids bugs when using enableInEditMode and changing the options when already initialized.
2. Properly cleans up when recompiling, the problem is that OnDestroy is not called when recompiling.

See commit messages for details.