### PR TITLE
Set Script executionOrder in .meta

### DIFF
--- a/scripts/DllManipulatorScript.cs.meta
+++ b/scripts/DllManipulatorScript.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -10000
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
This prevents most people from having to set the execution order of events in the setup (`Edit > Project Settings > Script Execution Order`).