### PR TITLE
Fix il2cpp builds

### DIFF
--- a/stubLluiPlugin.c.meta
+++ b/stubLluiPlugin.c.meta
@@ -12,9 +12,20 @@ PluginImporter:
   validateReferences: 1
   platformData:
   - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude WebGL: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor


### PR DESCRIPTION
Previously Unity would try to compile the `.c` file, but now it is ignored. IL2CPP builds will fail otherwise.