### PR TITLE
Add support for .Net Standard in Unity 2021 and higher

### DIFF
--- a/scripts/DllManipulator.cs
+++ b/scripts/DllManipulator.cs
@@ -416,8 +416,15 @@ namespace UnityNativeTool.Internal
             if (_customDelegateTypesModule == null)
             {
                 var aName = new AssemblyName("HelperRuntimeDelegates");
+
+                 #if NETSTANDARD
+                var delegateTypesAssembly = AssemblyBuilder.DefineDynamicAssembly(aName, AssemblyBuilderAccess.Run);
+                _customDelegateTypesModule = delegateTypesAssembly.DefineDynamicModule(aName.Name + ".dll");
+                #else
                 var delegateTypesAssembly = AppDomain.CurrentDomain.DefineDynamicAssembly(aName, AssemblyBuilderAccess.RunAndSave);
                 _customDelegateTypesModule = delegateTypesAssembly.DefineDynamicModule(aName.Name, aName.Name + ".dll");
+                #endif
+
             }
 
             var delBuilder = _customDelegateTypesModule.DefineType("HelperNativeDelegate" + _createdDelegateTypes.ToString(),


### PR DESCRIPTION
- Add support for .NET STandard in Unity 2021 and higher.
- Keep retro-compatibility using the compilation directive #NETSTANDARD

Notes:
- Untested on windows.
